### PR TITLE
Update iOS Deployment Target for libarclite

### DIFF
--- a/PersistenceKit.podspec
+++ b/PersistenceKit.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
     s.swift_version = "5.0"
     s.requires_arc = true
 
-    s.ios.deployment_target = "8.0"
+    s.ios.deployment_target = "9.0"
     s.osx.deployment_target = "10.10"
     s.tvos.deployment_target = "9.0"
     s.watchos.deployment_target = "2.0"


### PR DESCRIPTION
`SDK does not contain 'libarclite' at the path 'Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/arc/libarclite_iphonesimulator.a'; try increasing the minimum deployment target` error gets when iOS Deployment Target is **8.0**. iOS Deployment Target needs to be updated to **9.0** to fix this error.